### PR TITLE
Add service to stop recording - Set bag name when recording is started

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,10 @@ Alternatively, use the python script:
 ```
 ros2 run rosbag2_composable_recorder start_recording.py
 ```
-To stop the recording you have to kill (Ctrl-C) the recording driver.
+To stop the recording you have to kill (Ctrl-C) the recording driver or to call the stop service
+```
+ros2 service call /stop_recording std_srvs/srv/Trigger
+```
 
 ## Parameters
 

--- a/README.md
+++ b/README.md
@@ -45,14 +45,17 @@ Alternatively, use the python script:
 ```
 ros2 run rosbag2_composable_recorder start_recording.py
 ```
-To stop the recording you have to kill (Ctrl-C) the recording driver or to call the stop service
+To stop the recording, either kill (Ctrl-C) the recording driver or call the stop service:
 ```
 ros2 service call /stop_recording std_srvs/srv/Trigger
 ```
 
 ## Parameters
 
-- ``bag_name``: (default: empty) prefix of directory name used for bag.
+- ``bag_name``: (default: empty) prefix of directory name used for
+    bag. Note: if you stop the recording and restart, the recorder node
+    will throw an exception and exit because the bag already
+    exists. Use ``bag_prefix`` in this case.
 - ``bag_prefix``: (default: ``rosbag_2``) prefix of directory name used for storage. A
     timestamp will be appended. This parameter is only used when no
     ``bag_name`` is specified.

--- a/include/rosbag2_composable_recorder/composable_recorder.hpp
+++ b/include/rosbag2_composable_recorder/composable_recorder.hpp
@@ -34,7 +34,7 @@ private:
   bool startRecording(
     const std::shared_ptr<std_srvs::srv::Trigger::Request> req,
     std::shared_ptr<std_srvs::srv::Trigger::Response> res);
-  
+
   bool stopRecording(
     const std::shared_ptr<std_srvs::srv::Trigger::Request> req,
     std::shared_ptr<std_srvs::srv::Trigger::Response> res);

--- a/include/rosbag2_composable_recorder/composable_recorder.hpp
+++ b/include/rosbag2_composable_recorder/composable_recorder.hpp
@@ -43,6 +43,8 @@ private:
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr start_service_;
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr stop_service_;
   bool isRecording_{false};
+  std::string bag_name_;
+  std::string bag_prefix_;
 };
 
 }  // namespace rosbag2_composable_recorder

--- a/include/rosbag2_composable_recorder/composable_recorder.hpp
+++ b/include/rosbag2_composable_recorder/composable_recorder.hpp
@@ -34,9 +34,14 @@ private:
   bool startRecording(
     const std::shared_ptr<std_srvs::srv::Trigger::Request> req,
     std::shared_ptr<std_srvs::srv::Trigger::Response> res);
+  
+  bool stopRecording(
+    const std::shared_ptr<std_srvs::srv::Trigger::Request> req,
+    std::shared_ptr<std_srvs::srv::Trigger::Response> res);
 
   // ---- variables
-  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr service_;
+  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr start_service_;
+  rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr stop_service_;
   bool isRecording_{false};
 };
 

--- a/src/composable_recorder.cpp
+++ b/src/composable_recorder.cpp
@@ -88,9 +88,9 @@ ComposableRecorder::ComposableRecorder(const rclcpp::NodeOptions & options)
         &ComposableRecorder::startRecording, this, std::placeholders::_1, std::placeholders::_2));
   }
   stop_service_ = create_service<std_srvs::srv::Trigger>(
-      "stop_recording",
-      std::bind(
-        &ComposableRecorder::stopRecording, this, std::placeholders::_1, std::placeholders::_2));
+    "stop_recording",
+    std::bind(
+      &ComposableRecorder::stopRecording, this, std::placeholders::_1, std::placeholders::_2));
 }
 
 bool ComposableRecorder::startRecording(


### PR DESCRIPTION
This PR add the service `stop_recording` to stop the recording.
The behaviour of the service matches the one of  `start_recording`.

To allow multiple recordings to be started and stopped without having to restart the node, the rosbag name is now set when the recording is triggered. This ensures that the time stamps are unique and properly assigned.

### Current limitations

Only when using `bag_prefix` the bag names are unique among multiple recordings. When using `bag_name`, if the first record is stopped and then a second is attempted to start, you will get the error

```sh
"runtime error occurred: Database directory already exists (rosbag2_***), can't overwrite existing database"
```