### PR TITLE
feat: Add parameters for splitting bags according to max size and max duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ ros2 service call /stop_recording std_srvs/srv/Trigger
 - ``serialization_format``: (default: cdr) serialization format.
 - ``max_cache_size``: (default: 100MB) size (in bytes) of cache before
     writing to disk. See ``ros2 bag record --help`` for more.
+- ``max_bagfile_size``: (default: 0MB) maximum size a bagfile can be before it is split.
+    A value of 0 indicates that bagfile splitting will not be used.
+    See ``ros2 bag record --help`` for more.
+- ``max_bagfile_duration``: (default: 0s) maximum duration a bagfile can be before it is split.
+    A value of 0 indicates that bagfile splitting will not be used.
+    See ``ros2 bag record --help`` for more.
 - ``start_recording_immediately``: (default: False) do not wait for
     service call before recording is started.
 

--- a/src/composable_recorder.cpp
+++ b/src/composable_recorder.cpp
@@ -54,6 +54,8 @@ ComposableRecorder::ComposableRecorder(const rclcpp::NodeOptions & options)
 #endif
   sopt.storage_id = declare_parameter<std::string>("storage_id", "sqlite3");
   sopt.max_cache_size = declare_parameter<int>("max_cache_size", 100 * 1024 * 1024);
+  sopt.max_bagfile_size = declare_parameter<int>("max_bagfile_size", 0);
+  sopt.max_bagfile_duration = declare_parameter<int>("max_bagfile_duration", 0);
 
   // set recorder options
 #ifdef USE_GET_RECORD_OPTIONS


### PR DESCRIPTION
It would be useful to have this features exposed to the main node parameters.