### PR TITLE
Fix database directory creation error when starting recording

### DIFF
--- a/src/composable_recorder.cpp
+++ b/src/composable_recorder.cpp
@@ -82,7 +82,13 @@ ComposableRecorder::ComposableRecorder(const rclcpp::NodeOptions & options)
   }
 
   if (declare_parameter<bool>("start_recording_immediately", false)) {
+    if (!bag_name_.empty()) {
+      sopt.uri = bag_name_;
+    } else {
+      sopt.uri = bag_prefix_ + get_time_stamp();
+    }
     record();
+    isRecording_ = true;
   } else {
     start_service_ = create_service<std_srvs::srv::Trigger>(
       "start_recording",


### PR DESCRIPTION
When start_recording_immediately is True, there is an error happening

```
Component constructor threw an exception: Failed to create database directory ().
```

which was caused by `sopt.uri` not being set.

This PR sets `sopt.uri` directly as done when the trigger starts.