### PR TITLE
added qos override support and namespace topic resolve

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ set(ROS2_DEPENDENCIES
   "rclcpp"
   "rclcpp_components"
   "std_srvs"
+  "rosbag2_storage"
   "rosbag2_transport"
 )
 foreach(pkg ${ROS2_DEPENDENCIES})
@@ -85,6 +86,11 @@ install(DIRECTORY
   launch
   DESTINATION share/${PROJECT_NAME}/
   FILES_MATCHING PATTERN "*.py")
+
+install(DIRECTORY
+  config
+  DESTINATION share/${PROJECT_NAME}/
+  FILES_MATCHING PATTERN "*.yaml")
 
 if(BUILD_TESTING)
   find_package(ament_cmake REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ set(ROS2_DEPENDENCIES
   "std_srvs"
   "rosbag2_storage"
   "rosbag2_transport"
+  "yaml-cpp"
 )
 foreach(pkg ${ROS2_DEPENDENCIES})
   find_package(${pkg} REQUIRED)

--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ qos_profile_overrides_path: /absolute/path/to/qos_overrides.yaml
 ```
 
 A sample override file is included in
-[config/qos_overrides.yaml](config/qos_overrides.yaml).
+[config/qos_overrides.yaml](config/qos_overrides.yaml). The launch file does not
+apply it by default; pass this file explicitly if you want these overrides.
 
 Example ``qos_overrides.yaml``:
 ```

--- a/README.md
+++ b/README.md
@@ -60,11 +60,17 @@ ros2 service call /stop_recording std_srvs/srv/Trigger
     timestamp will be appended. This parameter is only used when no
     ``bag_name`` is specified.
 - ``topics``: (default: empty) array of strings that specifies the topics to record.
+    Topic names are expanded against the recorder node namespace, so relative
+    names (without leading ``/``) are namespace-aware.
 - ``record_all``: (default: False) when this is set, all topics are recorded.
 - ``disable_discovery``: (default: False) disable discovery of topics
     that occured after recording was launched.
 - ``storage_id``: (default: sqlite3) storage container format.
 - ``serialization_format``: (default: cdr) serialization format.
+- ``qos_profile_overrides_path``: (default: empty) path to a YAML file
+    containing per-topic QoS profiles. This matches rosbag2 behavior.
+    Topic keys are expanded against the recorder node namespace, so relative
+    topic names (without leading ``/``) are namespace-aware.
 - ``max_cache_size``: (default: 100MB) size (in bytes) of cache before
     writing to disk. See ``ros2 bag record --help`` for more.
 - ``max_bagfile_size``: (default: 0MB) maximum size a bagfile can be before it is split.
@@ -75,6 +81,32 @@ ros2 service call /stop_recording std_srvs/srv/Trigger
     See ``ros2 bag record --help`` for more.
 - ``start_recording_immediately``: (default: False) do not wait for
     service call before recording is started.
+
+QoS override file example:
+```
+qos_profile_overrides_path: /absolute/path/to/qos_overrides.yaml
+```
+
+A sample override file is included in
+[config/qos_overrides.yaml](config/qos_overrides.yaml).
+
+Example ``qos_overrides.yaml``:
+```
+camera/image_raw:
+    history: keep_last
+    depth: 10
+    reliability: best_effort
+    durability: volatile
+
+/tf_static:
+    history: keep_last
+    depth: 1
+    reliability: reliable
+    durability: transient_local
+```
+
+If you run the recorder under namespace ``/robot1``, the example key
+``camera/image_raw`` is resolved as ``/robot1/camera/image_raw``.
 
 
 ## License

--- a/config/qos_overrides.yaml
+++ b/config/qos_overrides.yaml
@@ -1,0 +1,11 @@
+camera/image_raw:
+  history: keep_last
+  depth: 10
+  reliability: best_effort
+  durability: volatile
+
+/tf_static:
+  history: keep_last
+  depth: 1
+  reliability: reliable
+  durability: transient_local

--- a/launch/recorder.launch.py
+++ b/launch/recorder.launch.py
@@ -18,7 +18,9 @@
 import launch
 from launch_ros.actions import ComposableNodeContainer
 from launch_ros.descriptions import ComposableNode
+from launch_ros.substitutions import FindPackageShare
 from launch.substitutions import LaunchConfiguration as LaunchConfig
+from launch.substitutions import PathJoinSubstitution
 from launch.actions import DeclareLaunchArgument as LaunchArg
 from launch.actions import OpaqueFunction
 
@@ -26,6 +28,7 @@ from launch.actions import OpaqueFunction
 def launch_setup(context, *args, **kwargs):
     """Create composable node."""
     bag_prefix = LaunchConfig('bag_prefix')
+    qos_profile_overrides_path = LaunchConfig('qos_profile_overrides_path')
     container = ComposableNodeContainer(
             name='composable_recorder_container',
             namespace='',
@@ -46,6 +49,7 @@ def launch_setup(context, *args, **kwargs):
                                  'record_all': False,
                                  'disable_discovery': False,
                                  'serialization_format': 'cdr',
+                                 'qos_profile_overrides_path': qos_profile_overrides_path,
                                  'start_recording_immediately': False,
                                  'bag_prefix': bag_prefix}],
                     remappings=[],
@@ -64,5 +68,10 @@ def generate_launch_description():
     return launch.LaunchDescription([
         LaunchArg('bag_prefix', default_value=['rosbag2_'],
                   description='prefix of rosbag'),
+        LaunchArg(
+            'qos_profile_overrides_path',
+            default_value=PathJoinSubstitution(
+                [FindPackageShare('rosbag2_composable_recorder'), 'config', 'qos_overrides.yaml']),
+            description='path to rosbag2 QoS override YAML file'),
         OpaqueFunction(function=launch_setup)
         ])

--- a/launch/recorder.launch.py
+++ b/launch/recorder.launch.py
@@ -18,9 +18,7 @@
 import launch
 from launch_ros.actions import ComposableNodeContainer
 from launch_ros.descriptions import ComposableNode
-from launch_ros.substitutions import FindPackageShare
 from launch.substitutions import LaunchConfiguration as LaunchConfig
-from launch.substitutions import PathJoinSubstitution
 from launch.actions import DeclareLaunchArgument as LaunchArg
 from launch.actions import OpaqueFunction
 
@@ -70,8 +68,7 @@ def generate_launch_description():
                   description='prefix of rosbag'),
         LaunchArg(
             'qos_profile_overrides_path',
-            default_value=PathJoinSubstitution(
-                [FindPackageShare('rosbag2_composable_recorder'), 'config', 'qos_overrides.yaml']),
+            default_value='',
             description='path to rosbag2 QoS override YAML file'),
         OpaqueFunction(function=launch_setup)
         ])

--- a/package.xml
+++ b/package.xml
@@ -17,6 +17,7 @@
   <depend>std_srvs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
+  <depend>rosbag2_storage</depend>
   <depend>rosbag2_transport</depend>
   
   <export>

--- a/package.xml
+++ b/package.xml
@@ -19,6 +19,7 @@
   <depend>rclcpp_components</depend>
   <depend>rosbag2_storage</depend>
   <depend>rosbag2_transport</depend>
+  <depend>yaml-cpp</depend>
   
   <export>
     <build_type>ament_cmake</build_type>

--- a/src/composable_recorder.cpp
+++ b/src/composable_recorder.cpp
@@ -29,8 +29,7 @@ namespace rosbag2_composable_recorder
 namespace
 {
 std::string resolve_topic_name(
-  const std::string & topic_name, const rclcpp::Logger & logger,
-  const std::string & node_name,
+  const std::string & topic_name, const rclcpp::Logger & logger, const std::string & node_name,
   const std::string & node_namespace, const char * context)
 {
   try {
@@ -106,8 +105,7 @@ rclcpp::QoS make_qos_from_yaml_node(
 void load_qos_profile_overrides_from_file(
   const std::string & qos_profile_overrides_path,
   std::unordered_map<std::string, rclcpp::QoS> & topic_qos_profile_overrides,
-  const rclcpp::Logger & logger, const std::string & node_name,
-  const std::string & node_namespace)
+  const rclcpp::Logger & logger, const std::string & node_name, const std::string & node_namespace)
 {
   // Parse QoS override YAML with yaml-cpp directly for compatibility with setups
   // where rosbag2_storage QoS YAML helper headers are not available via includes.

--- a/src/composable_recorder.cpp
+++ b/src/composable_recorder.cpp
@@ -30,14 +30,15 @@ namespace
 {
 std::string resolve_topic_name(
   const std::string & topic_name, const rclcpp::Logger & logger,
-  const std::string & node_name, const std::string & node_namespace, const char * context)
+  const std::string & node_name,
+  const std::string & node_namespace, const char * context)
 {
   try {
     return rclcpp::expand_topic_or_service_name(topic_name, node_name, node_namespace, false);
   } catch (const std::exception & ex) {
     RCLCPP_WARN_STREAM(
       logger, "failed to expand " << context << " topic name '" << topic_name << "': " << ex.what()
-                                   << ". using raw topic name.");
+                                  << ". using raw topic name.");
     return topic_name;
   }
 }
@@ -56,7 +57,7 @@ rclcpp::QoS make_qos_from_yaml_node(
     } else {
       RCLCPP_WARN_STREAM(
         logger, "unsupported history='" << history << "' for topic '" << topic_name
-                                         << "', using keep_last.");
+                                        << "', using keep_last.");
     }
   }
 
@@ -82,7 +83,7 @@ rclcpp::QoS make_qos_from_yaml_node(
     } else {
       RCLCPP_WARN_STREAM(
         logger, "unsupported reliability='" << reliability << "' for topic '" << topic_name
-                                             << "', using system default.");
+                                            << "', using system default.");
     }
   }
 
@@ -95,7 +96,7 @@ rclcpp::QoS make_qos_from_yaml_node(
     } else {
       RCLCPP_WARN_STREAM(
         logger, "unsupported durability='" << durability << "' for topic '" << topic_name
-                                            << "', using system default.");
+                                           << "', using system default.");
     }
   }
 
@@ -104,8 +105,9 @@ rclcpp::QoS make_qos_from_yaml_node(
 
 void load_qos_profile_overrides_from_file(
   const std::string & qos_profile_overrides_path,
-  std::unordered_map<std::string, rclcpp::QoS> & topic_qos_profile_overrides, const rclcpp::Logger & logger,
-  const std::string & node_name, const std::string & node_namespace)
+  std::unordered_map<std::string, rclcpp::QoS> & topic_qos_profile_overrides,
+  const rclcpp::Logger & logger, const std::string & node_name,
+  const std::string & node_namespace)
 {
   // Parse QoS override YAML with yaml-cpp directly for compatibility with setups
   // where rosbag2_storage QoS YAML helper headers are not available via includes.
@@ -128,7 +130,7 @@ void load_qos_profile_overrides_from_file(
 
   RCLCPP_INFO_STREAM(
     logger, "loaded " << topic_qos_profile_overrides.size()
-                       << " QoS override entries from: " << qos_profile_overrides_path);
+                      << " QoS override entries from: " << qos_profile_overrides_path);
 }
 }  // namespace
 

--- a/src/composable_recorder.cpp
+++ b/src/composable_recorder.cpp
@@ -21,9 +21,131 @@
 #include <iomanip>
 #include <rclcpp_components/register_node_macro.hpp>
 #include <sstream>
+#include <stdexcept>
+#include <yaml-cpp/yaml.h>
 
 namespace rosbag2_composable_recorder
 {
+namespace
+{
+std::string resolve_topic_name(
+  const std::string & topic_name,
+  const rclcpp::Logger & logger,
+  const std::string & node_name,
+  const std::string & node_namespace,
+  const char * context)
+{
+  try {
+    return rclcpp::expand_topic_or_service_name(topic_name, node_name, node_namespace, false);
+  } catch (const std::exception & ex) {
+    RCLCPP_WARN_STREAM(
+      logger,
+      "failed to expand " << context << " topic name '" << topic_name << "': " << ex.what() <<
+        ". using raw topic name.");
+    return topic_name;
+  }
+}
+
+rclcpp::QoS make_qos_from_yaml_node(
+  const YAML::Node & qos_node,
+  const rclcpp::Logger & logger,
+  const std::string & topic_name)
+{
+  auto qos = rclcpp::QoS(rclcpp::KeepLast(rmw_qos_profile_default.depth));
+
+  if (qos_node["history"]) {
+    const auto history = qos_node["history"].as<std::string>();
+    if (history == "keep_last") {
+      // depth is handled below.
+    } else if (history == "keep_all") {
+      qos.keep_all();
+    } else {
+      RCLCPP_WARN_STREAM(
+        logger,
+        "unsupported history='" << history << "' for topic '" << topic_name <<
+          "', using keep_last.");
+    }
+  }
+
+  if (qos_node["depth"]) {
+    const auto depth = qos_node["depth"].as<int>();
+    if (depth < 1) {
+      RCLCPP_WARN_STREAM(
+        logger,
+        "invalid depth=" << depth << " for topic '" << topic_name << "', using depth=1.");
+      if (qos.get_rmw_qos_profile().history != RMW_QOS_POLICY_HISTORY_KEEP_ALL) {
+        qos.keep_last(1);
+      }
+    } else if (qos.get_rmw_qos_profile().history != RMW_QOS_POLICY_HISTORY_KEEP_ALL) {
+      qos.keep_last(static_cast<size_t>(depth));
+    }
+  }
+
+  if (qos_node["reliability"]) {
+    const auto reliability = qos_node["reliability"].as<std::string>();
+    if (reliability == "reliable") {
+      qos.reliable();
+    } else if (reliability == "best_effort") {
+      qos.best_effort();
+    } else {
+      RCLCPP_WARN_STREAM(
+        logger,
+        "unsupported reliability='" << reliability << "' for topic '" << topic_name <<
+          "', using system default.");
+    }
+  }
+
+  if (qos_node["durability"]) {
+    const auto durability = qos_node["durability"].as<std::string>();
+    if (durability == "volatile") {
+      qos.durability_volatile();
+    } else if (durability == "transient_local") {
+      qos.transient_local();
+    } else {
+      RCLCPP_WARN_STREAM(
+        logger,
+        "unsupported durability='" << durability << "' for topic '" << topic_name <<
+          "', using system default.");
+    }
+  }
+
+  return qos;
+}
+
+void load_qos_profile_overrides_from_file(
+  const std::string & qos_profile_overrides_path,
+  std::unordered_map<std::string, rclcpp::QoS> & topic_qos_profile_overrides,
+  const rclcpp::Logger & logger,
+  const std::string & node_name,
+  const std::string & node_namespace)
+{
+  // Parse QoS override YAML with yaml-cpp directly for compatibility with setups
+  // where rosbag2_storage QoS YAML helper headers are not available via includes.
+  try {
+    YAML::Node yaml_file = YAML::LoadFile(qos_profile_overrides_path);
+    std::unordered_map<std::string, rclcpp::QoS> qos_overrides;
+    for (const auto & topic_qos : yaml_file) {
+      const auto topic_name = topic_qos.first.as<std::string>();
+      auto resolved_topic_name =
+        resolve_topic_name(topic_name, logger, node_name, node_namespace, "QoS override");
+
+      qos_overrides.emplace(
+        resolved_topic_name,
+        make_qos_from_yaml_node(topic_qos.second, logger, resolved_topic_name));
+    }
+    topic_qos_profile_overrides = std::move(qos_overrides);
+  } catch (const YAML::Exception & ex) {
+    throw std::runtime_error(
+            std::string("Exception on parsing QoS overrides file: ") + ex.what());
+  }
+
+  RCLCPP_INFO_STREAM(
+    logger,
+    "loaded " << topic_qos_profile_overrides.size() << " QoS override entries from: " <<
+      qos_profile_overrides_path);
+}
+}  // namespace
+
 static std::string get_time_stamp()
 {
   std::stringstream datetime;
@@ -41,10 +163,15 @@ ComposableRecorder::ComposableRecorder(const rclcpp::NodeOptions & options)
   bag_name_(declare_parameter<std::string>("bag_name", "")),
   bag_prefix_(declare_parameter<std::string>("bag_prefix", "rosbag2_"))
 {
-  std::vector<std::string> topics =
+  const std::vector<std::string> configured_topics =
     declare_parameter<std::vector<std::string>>("topics", std::vector<std::string>());
-  for (const auto & topic : topics) {
-    RCLCPP_INFO_STREAM(get_logger(), "recording topic: " << topic);
+  std::vector<std::string> topics;
+  topics.reserve(configured_topics.size());
+  for (const auto & topic : configured_topics) {
+    auto resolved_topic = resolve_topic_name(
+      topic, get_logger(), get_name(), get_namespace(), "record");
+    topics.emplace_back(resolved_topic);
+    RCLCPP_INFO_STREAM(get_logger(), "recording topic: " << resolved_topic);
   }
   // set storage options
 #ifdef USE_GET_STORAGE_OPTIONS
@@ -72,6 +199,21 @@ ComposableRecorder::ComposableRecorder(const rclcpp::NodeOptions & options)
   ropt.rmw_serialization_format = declare_parameter<std::string>("serialization_format", "cdr");
   ropt.topic_polling_interval = std::chrono::milliseconds(100);
   ropt.topics.insert(ropt.topics.end(), topics.begin(), topics.end());
+
+  const std::string qos_profile_overrides_path =
+    declare_parameter<std::string>("qos_profile_overrides_path", "");
+  if (!qos_profile_overrides_path.empty()) {
+    load_qos_profile_overrides_from_file(
+      qos_profile_overrides_path,
+      ropt.topic_qos_profile_overrides,
+      get_logger(),
+      get_name(),
+      get_namespace());
+  } else {
+    RCLCPP_INFO(
+      get_logger(),
+      "qos_profile_overrides_path is empty, no explicit QoS profile overrides will be applied.");
+  }
 
   if (ropt.is_discovery_disabled) {
 #ifdef USE_STOP_DISCOVERY

--- a/src/composable_recorder.cpp
+++ b/src/composable_recorder.cpp
@@ -16,40 +16,34 @@
 #include "rosbag2_composable_recorder/composable_recorder.hpp"
 
 #include <stdio.h>
+#include <yaml-cpp/yaml.h>
 
 #include <chrono>
 #include <iomanip>
 #include <rclcpp_components/register_node_macro.hpp>
 #include <sstream>
 #include <stdexcept>
-#include <yaml-cpp/yaml.h>
 
 namespace rosbag2_composable_recorder
 {
 namespace
 {
 std::string resolve_topic_name(
-  const std::string & topic_name,
-  const rclcpp::Logger & logger,
-  const std::string & node_name,
-  const std::string & node_namespace,
-  const char * context)
+  const std::string & topic_name, const rclcpp::Logger & logger,
+  const std::string & node_name, const std::string & node_namespace, const char * context)
 {
   try {
     return rclcpp::expand_topic_or_service_name(topic_name, node_name, node_namespace, false);
   } catch (const std::exception & ex) {
     RCLCPP_WARN_STREAM(
-      logger,
-      "failed to expand " << context << " topic name '" << topic_name << "': " << ex.what() <<
-        ". using raw topic name.");
+      logger, "failed to expand " << context << " topic name '" << topic_name << "': " << ex.what()
+                                   << ". using raw topic name.");
     return topic_name;
   }
 }
 
 rclcpp::QoS make_qos_from_yaml_node(
-  const YAML::Node & qos_node,
-  const rclcpp::Logger & logger,
-  const std::string & topic_name)
+  const YAML::Node & qos_node, const rclcpp::Logger & logger, const std::string & topic_name)
 {
   auto qos = rclcpp::QoS(rclcpp::KeepLast(rmw_qos_profile_default.depth));
 
@@ -61,9 +55,8 @@ rclcpp::QoS make_qos_from_yaml_node(
       qos.keep_all();
     } else {
       RCLCPP_WARN_STREAM(
-        logger,
-        "unsupported history='" << history << "' for topic '" << topic_name <<
-          "', using keep_last.");
+        logger, "unsupported history='" << history << "' for topic '" << topic_name
+                                         << "', using keep_last.");
     }
   }
 
@@ -71,8 +64,7 @@ rclcpp::QoS make_qos_from_yaml_node(
     const auto depth = qos_node["depth"].as<int>();
     if (depth < 1) {
       RCLCPP_WARN_STREAM(
-        logger,
-        "invalid depth=" << depth << " for topic '" << topic_name << "', using depth=1.");
+        logger, "invalid depth=" << depth << " for topic '" << topic_name << "', using depth=1.");
       if (qos.get_rmw_qos_profile().history != RMW_QOS_POLICY_HISTORY_KEEP_ALL) {
         qos.keep_last(1);
       }
@@ -89,9 +81,8 @@ rclcpp::QoS make_qos_from_yaml_node(
       qos.best_effort();
     } else {
       RCLCPP_WARN_STREAM(
-        logger,
-        "unsupported reliability='" << reliability << "' for topic '" << topic_name <<
-          "', using system default.");
+        logger, "unsupported reliability='" << reliability << "' for topic '" << topic_name
+                                             << "', using system default.");
     }
   }
 
@@ -103,9 +94,8 @@ rclcpp::QoS make_qos_from_yaml_node(
       qos.transient_local();
     } else {
       RCLCPP_WARN_STREAM(
-        logger,
-        "unsupported durability='" << durability << "' for topic '" << topic_name <<
-          "', using system default.");
+        logger, "unsupported durability='" << durability << "' for topic '" << topic_name
+                                            << "', using system default.");
     }
   }
 
@@ -114,10 +104,8 @@ rclcpp::QoS make_qos_from_yaml_node(
 
 void load_qos_profile_overrides_from_file(
   const std::string & qos_profile_overrides_path,
-  std::unordered_map<std::string, rclcpp::QoS> & topic_qos_profile_overrides,
-  const rclcpp::Logger & logger,
-  const std::string & node_name,
-  const std::string & node_namespace)
+  std::unordered_map<std::string, rclcpp::QoS> & topic_qos_profile_overrides, const rclcpp::Logger & logger,
+  const std::string & node_name, const std::string & node_namespace)
 {
   // Parse QoS override YAML with yaml-cpp directly for compatibility with setups
   // where rosbag2_storage QoS YAML helper headers are not available via includes.
@@ -135,14 +123,12 @@ void load_qos_profile_overrides_from_file(
     }
     topic_qos_profile_overrides = std::move(qos_overrides);
   } catch (const YAML::Exception & ex) {
-    throw std::runtime_error(
-            std::string("Exception on parsing QoS overrides file: ") + ex.what());
+    throw std::runtime_error(std::string("Exception on parsing QoS overrides file: ") + ex.what());
   }
 
   RCLCPP_INFO_STREAM(
-    logger,
-    "loaded " << topic_qos_profile_overrides.size() << " QoS override entries from: " <<
-      qos_profile_overrides_path);
+    logger, "loaded " << topic_qos_profile_overrides.size()
+                       << " QoS override entries from: " << qos_profile_overrides_path);
 }
 }  // namespace
 
@@ -168,8 +154,8 @@ ComposableRecorder::ComposableRecorder(const rclcpp::NodeOptions & options)
   std::vector<std::string> topics;
   topics.reserve(configured_topics.size());
   for (const auto & topic : configured_topics) {
-    auto resolved_topic = resolve_topic_name(
-      topic, get_logger(), get_name(), get_namespace(), "record");
+    auto resolved_topic =
+      resolve_topic_name(topic, get_logger(), get_name(), get_namespace(), "record");
     topics.emplace_back(resolved_topic);
     RCLCPP_INFO_STREAM(get_logger(), "recording topic: " << resolved_topic);
   }
@@ -204,10 +190,7 @@ ComposableRecorder::ComposableRecorder(const rclcpp::NodeOptions & options)
     declare_parameter<std::string>("qos_profile_overrides_path", "");
   if (!qos_profile_overrides_path.empty()) {
     load_qos_profile_overrides_from_file(
-      qos_profile_overrides_path,
-      ropt.topic_qos_profile_overrides,
-      get_logger(),
-      get_name(),
+      qos_profile_overrides_path, ropt.topic_qos_profile_overrides, get_logger(), get_name(),
       get_namespace());
   } else {
     RCLCPP_INFO(


### PR DESCRIPTION
Added ROS 2 Humble-compatible QoS override support for the composable recorder via [qos_profile_overrides_path] YAML, with namespace-aware topic resolution for both recorded topics and QoS override keys. 

This keeps behavior close to rosbag2, but avoids relying on rosbag2_storage/qos.hpp, which is not available as a usable public header on Humble in this environment. The YAML is parsed directly with yaml-cpp instead.